### PR TITLE
Fix license identifier in library.properties

### DIFF
--- a/library.properties
+++ b/library.properties
@@ -1,7 +1,7 @@
 name=SparkFun_WebServer_ESP32_W5500
 version=1.5.5
 author=SparkFun
-license=GPLv3
+license=GPL-3.0-or-later
 maintainer=SparkFun Electronics
 sentence=Simple Ethernet WebServer for ESP32 boards using W5500.
 paragraph=This library adds the W5500 as a physical Ethernet interface for the ESP32. The HTTP(S) methods are provided by WiFiServer and WiFiClient. Works great with me-no-dev's ESPAsyncWebServer.


### PR DESCRIPTION
`GPLv3` is not a valid license identifier.

It should be one of these:
* https://spdx.org/licenses/GPL-3.0-or-later.html
* https://spdx.org/licenses/GPL-3.0-only.html
